### PR TITLE
Restoring the advanced compressor

### DIFF
--- a/VoxelPlus/player.config.patch
+++ b/VoxelPlus/player.config.patch
@@ -54,6 +54,7 @@
 { "op": "add", "path": "/defaultBlueprints/tier1/-", "value" : { "item" : "essence200k" } },
 { "op": "add", "path": "/defaultBlueprints/tier1/-", "value" : { "item" : "essence500k" } },
 { "op": "add", "path": "/defaultBlueprints/tier1/-", "value" : { "item" : "essence1m" } },
+{ "op": "add", "path": "/defaultBlueprints/tier1/-", "value" : { "item" : "advancedcompressor" } },
 { "op": "add", "path": "/defaultBlueprints/tier1/-", "value" : { "item" : "compressaltar" } },
 { "op": "add", "path": "/defaultBlueprints/tier1/-", "value" : { "item" : "smalladvancedorestation" } },
 { "op": "add", "path": "/defaultBlueprints/tier1/-", "value" : { "item" : "smallbasicorestation" } },

--- a/VoxelPlus/recipes/advancedcompressor/compress/voxel500p.recipe
+++ b/VoxelPlus/recipes/advancedcompressor/compress/voxel500p.recipe
@@ -4,5 +4,5 @@
   ],
   "output" : { "item" : "voxel500p", "count" : 1 },
   "duration" : 0.9,
-  "groups" : [ "aacompressor", "advcompress" ]
+  "groups" : [ "acompressor", "advcompress" ]
 }

--- a/VoxelPlus/recipes/pixelcompressor/compress/voxel10k.recipe.patch
+++ b/VoxelPlus/recipes/pixelcompressor/compress/voxel10k.recipe.patch
@@ -1,0 +1,4 @@
+[
+  {"op":"add","path":"/groups/-","value":"acompressor"}
+  {"op":"add","path":"/groups/-","value":"advdecompress"}
+]

--- a/VoxelPlus/recipes/pixelcompressor/compress/voxel10k.recipe.patch
+++ b/VoxelPlus/recipes/pixelcompressor/compress/voxel10k.recipe.patch
@@ -1,4 +1,4 @@
 [
-  {"op":"add","path":"/groups/-","value":"acompressor"}
-  {"op":"add","path":"/groups/-","value":"advdecompress"}
+  {"op":"add","path":"/groups/-","value":"acompressor"},
+  {"op":"add","path":"/groups/-","value":"advcompress"}
 ]

--- a/VoxelPlus/recipes/pixelcompressor/compress/voxel1k.recipe.patch
+++ b/VoxelPlus/recipes/pixelcompressor/compress/voxel1k.recipe.patch
@@ -1,0 +1,4 @@
+[
+  {"op":"add","path":"/groups/-","value":"acompressor"}
+  {"op":"add","path":"/groups/-","value":"advdecompress"}
+]

--- a/VoxelPlus/recipes/pixelcompressor/compress/voxel1k.recipe.patch
+++ b/VoxelPlus/recipes/pixelcompressor/compress/voxel1k.recipe.patch
@@ -1,4 +1,4 @@
 [
-  {"op":"add","path":"/groups/-","value":"acompressor"}
-  {"op":"add","path":"/groups/-","value":"advdecompress"}
+  {"op":"add","path":"/groups/-","value":"acompressor"},
+  {"op":"add","path":"/groups/-","value":"advcompress"}
 ]

--- a/VoxelPlus/recipes/pixelcompressor/compress/voxel2k.recipe.patch
+++ b/VoxelPlus/recipes/pixelcompressor/compress/voxel2k.recipe.patch
@@ -1,0 +1,4 @@
+[
+  {"op":"add","path":"/groups/-","value":"acompressor"}
+  {"op":"add","path":"/groups/-","value":"advdecompress"}
+]

--- a/VoxelPlus/recipes/pixelcompressor/compress/voxel2k.recipe.patch
+++ b/VoxelPlus/recipes/pixelcompressor/compress/voxel2k.recipe.patch
@@ -1,4 +1,4 @@
 [
-  {"op":"add","path":"/groups/-","value":"acompressor"}
-  {"op":"add","path":"/groups/-","value":"advdecompress"}
+  {"op":"add","path":"/groups/-","value":"acompressor"},
+  {"op":"add","path":"/groups/-","value":"advcompress"}
 ]

--- a/VoxelPlus/recipes/pixelcompressor/compress/voxel5k.recipe.patch
+++ b/VoxelPlus/recipes/pixelcompressor/compress/voxel5k.recipe.patch
@@ -1,0 +1,4 @@
+[
+  {"op":"add","path":"/groups/-","value":"acompressor"}
+  {"op":"add","path":"/groups/-","value":"advdecompress"}
+]

--- a/VoxelPlus/recipes/pixelcompressor/compress/voxel5k.recipe.patch
+++ b/VoxelPlus/recipes/pixelcompressor/compress/voxel5k.recipe.patch
@@ -1,4 +1,4 @@
 [
-  {"op":"add","path":"/groups/-","value":"acompressor"}
-  {"op":"add","path":"/groups/-","value":"advdecompress"}
+  {"op":"add","path":"/groups/-","value":"acompressor"},
+  {"op":"add","path":"/groups/-","value":"advcompress"}
 ]

--- a/VoxelPlus/recipes/pixelcompressor/refine/voxel10k.recipe.patch
+++ b/VoxelPlus/recipes/pixelcompressor/refine/voxel10k.recipe.patch
@@ -1,0 +1,4 @@
+[
+  {"op":"add","path":"/groups/-","value":"acompressor"}
+  {"op":"add","path":"/groups/-","value":"advdecompress"}
+]

--- a/VoxelPlus/recipes/pixelcompressor/refine/voxel10k.recipe.patch
+++ b/VoxelPlus/recipes/pixelcompressor/refine/voxel10k.recipe.patch
@@ -1,4 +1,4 @@
 [
-  {"op":"add","path":"/groups/-","value":"acompressor"}
+  {"op":"add","path":"/groups/-","value":"acompressor"},
   {"op":"add","path":"/groups/-","value":"advdecompress"}
 ]

--- a/VoxelPlus/recipes/pixelcompressor/refine/voxel1k.recipe.patch
+++ b/VoxelPlus/recipes/pixelcompressor/refine/voxel1k.recipe.patch
@@ -1,0 +1,4 @@
+[
+  {"op":"add","path":"/groups/-","value":"acompressor"}
+  {"op":"add","path":"/groups/-","value":"advdecompress"}
+]

--- a/VoxelPlus/recipes/pixelcompressor/refine/voxel1k.recipe.patch
+++ b/VoxelPlus/recipes/pixelcompressor/refine/voxel1k.recipe.patch
@@ -1,4 +1,4 @@
 [
-  {"op":"add","path":"/groups/-","value":"acompressor"}
+  {"op":"add","path":"/groups/-","value":"acompressor"},
   {"op":"add","path":"/groups/-","value":"advdecompress"}
 ]

--- a/VoxelPlus/recipes/pixelcompressor/refine/voxel2k.recipe.patch
+++ b/VoxelPlus/recipes/pixelcompressor/refine/voxel2k.recipe.patch
@@ -1,0 +1,4 @@
+[
+  {"op":"add","path":"/groups/-","value":"acompressor"}
+  {"op":"add","path":"/groups/-","value":"advdecompress"}
+]

--- a/VoxelPlus/recipes/pixelcompressor/refine/voxel2k.recipe.patch
+++ b/VoxelPlus/recipes/pixelcompressor/refine/voxel2k.recipe.patch
@@ -1,4 +1,4 @@
 [
-  {"op":"add","path":"/groups/-","value":"acompressor"}
+  {"op":"add","path":"/groups/-","value":"acompressor"},
   {"op":"add","path":"/groups/-","value":"advdecompress"}
 ]

--- a/VoxelPlus/recipes/pixelcompressor/refine/voxel5k.recipe.patch
+++ b/VoxelPlus/recipes/pixelcompressor/refine/voxel5k.recipe.patch
@@ -1,0 +1,4 @@
+[
+  {"op":"add","path":"/groups/-","value":"acompressor"}
+  {"op":"add","path":"/groups/-","value":"advdecompress"}
+]

--- a/VoxelPlus/recipes/pixelcompressor/refine/voxel5k.recipe.patch
+++ b/VoxelPlus/recipes/pixelcompressor/refine/voxel5k.recipe.patch
@@ -1,4 +1,4 @@
 [
-  {"op":"add","path":"/groups/-","value":"acompressor"}
+  {"op":"add","path":"/groups/-","value":"acompressor"},
   {"op":"add","path":"/groups/-","value":"advdecompress"}
 ]

--- a/VoxelPlus/recipes/pixelstation/advancedcompressor.recipe
+++ b/VoxelPlus/recipes/pixelstation/advancedcompressor.recipe
@@ -1,12 +1,12 @@
 {
   "input" : [
-    { "item" : "pixelcompressor", "count" : 1 }
+    { "item" : "pixelcompressor", "count" : 1 },
     { "item" : "solariumstar", "count" : 20 }
   ],
   "output" : {
     "item" : "advancedcompressor",
     "count" : 1
   },
-  "duration" : 0.1,
+  "duration" : 5,
   "groups" : [ "pixelstation" ]
 }

--- a/VoxelPlus/recipes/pixelstation/advancedcompressor.recipe
+++ b/VoxelPlus/recipes/pixelstation/advancedcompressor.recipe
@@ -1,0 +1,12 @@
+{
+  "input" : [
+    { "item" : "pixelcompressor", "count" : 1 }
+    { "item" : "solariumstar", "count" : 20 }
+  ],
+  "output" : {
+    "item" : "advancedcompressor",
+    "count" : 1
+  },
+  "duration" : 0.1,
+  "groups" : [ "pixelstation" ]
+}


### PR DESCRIPTION
The advanced pixel compressor recipe is in and available, with the original compressor's functionality installed. The recipe can be seasoned to taste.

The 500p voxel was not showing up to the player due to an errant a; This has been corrected as well.

The changes have been tested on my game, which runs a large collection of mods, and seems stable. You may wish to confirm before releasing it into the wild.